### PR TITLE
The exit code rules for PostgreSQL 10.x and later are all the same.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: [bionic, xenial]
 language: rust
 before_install:
   - sudo apt-get -y install postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
-dist: [bionic, xenial]
+jobs:
+  include:
+    - os: linux
+      dist: xenial
+    - os: linux
+      dist: bionic
+
 language: rust
+
 before_install:
   - sudo apt-get -y install postgresql
   - export PATH="$(printf '%s:' /usr/lib/postgresql/*/bin)$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 jobs:
   include:
-    - os: linux
+    - name: Ubuntu Xenial
+      os: linux
       dist: xenial
-    - os: linux
+    - name: Ubuntu Bionic
+      os: linux
       dist: bionic
 
 language: rust

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,6 @@ language: rust
 
 before_install:
   - sudo apt-get -y install postgresql
+
+before_script:
   - export PATH="$(printf '%s:' /usr/lib/postgresql/*/bin)$PATH"

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -167,9 +167,9 @@ impl Cluster {
         // later versions, so here we check for specific codes to avoid
         // masking errors from insufficient permissions or missing
         // executables, for example.
-        let running = match version.major {
-            // PostgreSQL 10.x
-            10 => {
+        let running = match (version.major >= 10, version.major) {
+            // PostgreSQL 10.x and later.
+            (true, _) => {
                 // PostgreSQL 10
                 // https://www.postgresql.org/docs/10/static/app-pg-ctl.html
                 match code {
@@ -186,8 +186,8 @@ impl Cluster {
                     _ => None,
                 }
             }
-            // PostgreSQL 9.x
-            9 => {
+            // PostgreSQL 9.x only.
+            (false, 9) => {
                 // PostgreSQL 9.4+
                 // https://www.postgresql.org/docs/9.4/static/app-pg-ctl.html
                 // https://www.postgresql.org/docs/9.5/static/app-pg-ctl.html
@@ -235,7 +235,7 @@ impl Cluster {
                 }
             }
             // All other versions.
-            _ => None,
+            (_, _) => None,
         };
 
         match running {


### PR DESCRIPTION
This means it'll work with PostgreSQL 11.x and later too.