### PR TITLE
Ignore `SIGINT`, `SIGTERM`, and `SIGHUP`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = {version = "^3.1.0", features = ["derive", "env"]}
+ctrlc = { version = "^3.2.1", features = ["termination"] }
 either = "^1.6.1"
 nix = "^0.23.0"
 postgres = "^0.19.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,10 @@ fn shell(database_dir: PathBuf, database_name: &str) -> i32 {
                 .createdb(database_name)
                 .expect("could not create database");
         }
+        // Ignore SIGINT, TERM, and HUP (with ctrlc feature "termination"). The
+        // child process will receive the signal, presumably terminate, then
+        // we'll tidy up.
+        ctrlc::set_handler(|| ()).expect("could not set signal handler");
         cluster.shell(database_name).expect("shell failed");
     })
     .unwrap();
@@ -98,9 +102,13 @@ fn exec<T: AsRef<OsStr>>(
                 .createdb(database_name)
                 .expect("could not create database");
         }
+        // Ignore SIGINT, TERM, and HUP (with ctrlc feature "termination"). The
+        // child process will receive the signal, presumably terminate, then
+        // we'll tidy up.
+        ctrlc::set_handler(|| ()).expect("could not set signal handler");
         cluster
             .exec(database_name, command, args)
-            .expect("shell failed");
+            .expect("exec failed");
     })
     .unwrap();
 


### PR DESCRIPTION
Ignore `SIGINT`, `TERM`, and `HUP`. The child process will receive the signal, presumably terminate, then `postgresfixture` will tidy up.

Fixes #68.