### PR TITLE
Make run_and_close and run_and_destroy actually do the shutdown operation even after a panic

### DIFF
--- a/src/coordinate.rs
+++ b/src/coordinate.rs
@@ -39,10 +39,10 @@ where
     F: std::panic::UnwindSafe + FnOnce() -> T,
 {
     let lock = startup(cluster, lock)?;
-    let result = std::panic::catch_unwind(action);
-    let shutdown_res = shutdown(cluster, lock, |cluster| cluster.stop())?;
-    match result {
-        Ok(result) => shutdown_res.map(|_| result),
+    let action_res = std::panic::catch_unwind(action);
+    let _: Option<bool> = shutdown(cluster, lock, |cluster| cluster.stop())?;
+    match action_res {
+        Ok(result) => Ok(result),
         Err(err) => std::panic::resume_unwind(err),
     }
 }
@@ -63,9 +63,9 @@ where
     F: std::panic::UnwindSafe + FnOnce() -> T,
 {
     let lock = startup(cluster, lock)?;
-    let result = std::panic::catch_unwind(action);
+    let action_res = std::panic::catch_unwind(action);
     let shutdown_res = shutdown(cluster, lock, |cluster| cluster.destroy());
-    match result {
+    match action_res {
         Ok(result) => shutdown_res.map(|_| result),
         Err(err) => std::panic::resume_unwind(err),
     }

--- a/src/coordinate.rs
+++ b/src/coordinate.rs
@@ -36,7 +36,7 @@ pub fn run_and_stop<F, T>(
     action: F,
 ) -> Result<T, ClusterError>
 where
-    F: FnOnce() -> T,
+    F: std::panic::UnwindSafe + FnOnce() -> T,
 {
     let lock = startup(cluster, lock)?;
     let result = std::panic::catch_unwind(action);
@@ -60,7 +60,7 @@ pub fn run_and_destroy<F, T>(
     action: F,
 ) -> Result<T, ClusterError>
 where
-    F: UnwindSafe + FnOnce() -> T,
+    F: std::panic::UnwindSafe + FnOnce() -> T,
 {
     let lock = startup(cluster, lock)?;
     let result = std::panic::catch_unwind(action);

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,7 +85,7 @@ const UUID_NS: uuid::Uuid = uuid::Uuid::from_u128(938751034366334704143487503057
 
 fn run<F>(database_dir: PathBuf, database_name: &str, destroy: bool, action: F) -> Result<i32>
 where
-    F: FnOnce(&cluster::Cluster) -> Result<i32>,
+    F: FnOnce(&cluster::Cluster) -> Result<i32> + std::panic::UnwindSafe,
 {
     // Create the cluster directory first.
     match fs::create_dir(&database_dir) {


### PR DESCRIPTION
Hey!

I'm looking into postgresfixture to run my tests, and noticed that run_and_close and run_and_destroy do not currently actually execute the on-shutdown behavior if there was a panic.

Here is a PR fixing this. Disclaimer: I wrote it from the github code editor, so it's completely untested :sweat_smile: 

Anyway, it seems like a quite nice tool! :)