### PR TITLE
Switch default database to `postgres`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,17 @@
-target/
-**/*.rs.bk
-**/scratch.rs
-Cargo.lock
-.*.lock
+# At present, Cargo.lock is not tracked. I think this is mostly beneficial for
+# those folks who use postgresfixture as a library, but can mean that it may not
+# build as a binary, e.g. via `cargo install postgresfixture`.
+/Cargo.lock
+
+# The default PGDATA for the `postgresfixture` binary – or `cargo run` – is
+# `cluster`. Ignore it by default; like it or not, it's going to get created
+# when mucking around.
+/cluster/
+
+# Rust build stuff.
+/target/
+
+# Experimentation!
+/scratch.rs
+
+# End.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ $ postgresfixture runtimes
 => 14.2       /usr/local/bin
 
 $ postgresfixture shell
-data=# select …
+postgres=# select …
 
 $ postgresfixture exec pg_dump
 --

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -68,7 +68,7 @@ pub struct DatabaseArgs {
         long = "database",
         env = "PGDATABASE",
         value_name = "PGDATABASE",
-        default_value = "data",
+        default_value = "postgres",
         display_order = 2
     )]
     pub name: String,


### PR DESCRIPTION
Previously it was `data`, but `initdb` creates the `postgres` database by default and it's explicitly intended for this kind of use:

> The postgres database is a default database meant for use by users, utilities
> and third party applications.
    -- https://www.postgresql.org/docs/16/app-initdb.html

Fixes #85.