### PR TITLE
Enable `fsync` by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-authors = ["Gavin Panella <gavinpanella@gmail.com>"]
+authors = ["Gavin Panella <gavin@allenap.me>"]
 categories = [
     "command-line-utilities",
     "database",

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -282,7 +282,6 @@ impl Cluster {
         //  -w -- wait until startup is complete.
         // postgres options:
         //  -h <arg> -- host name; empty arg means Unix socket only.
-        //  -F -- don't bother fsync'ing.
         //  -k -- socket directory.
         self.ctl()
             .arg("start")
@@ -292,7 +291,7 @@ impl Cluster {
             .arg("-w")
             .arg("-o")
             .arg({
-                let mut arg = b"-h '' -F -k "[..].into();
+                let mut arg = b"-h '' -k "[..].into();
                 escape_into(&self.datadir, &mut arg);
                 OsString::from_vec(arg)
             })

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -1,9 +1,10 @@
 //! Create, start, introspect, stop, and destroy PostgreSQL clusters.
 
 use std::ffi::{OsStr, OsString};
+use std::io::Write;
 use std::os::unix::prelude::OsStringExt;
 use std::path::{Path, PathBuf};
-use std::process::{Command, ExitStatus, Output};
+use std::process::{Command, ExitStatus, Output, Stdio};
 use std::{env, error, fmt, fs, io};
 
 use nix::errno::Errno;
@@ -411,6 +412,27 @@ impl Cluster {
             Ok(false)
         }
     }
+
+    pub fn single(&self, commands: &[&str]) -> Result<Output, ClusterError> {
+        let mut child = self
+            .runtime
+            .execute("postgres")
+            .env("PGDATA", &self.datadir)
+            .env("PGHOST", &self.datadir)
+            .arg("--single")
+            .arg("-j")
+            .arg("template1")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()?;
+        child
+            .stdin
+            .as_mut()
+            .ok_or(ClusterError::IoError(io::ErrorKind::BrokenPipe.into()))?
+            .write_all(commands.join(";\n\n").as_bytes())?;
+        Ok(child.wait_with_output()?)
+    }
 }
 
 #[cfg(test)]
@@ -423,6 +445,8 @@ mod tests {
     use std::fs::File;
     use std::path::{Path, PathBuf};
     use std::str::FromStr;
+
+    type TestResult = std::result::Result<(), super::ClusterError>;
 
     #[test]
     fn cluster_new() {
@@ -657,5 +681,23 @@ mod tests {
             cluster.dropdb("Foo-BAR").unwrap();
             cluster.destroy().unwrap();
         }
+    }
+
+    #[test]
+    fn cluster_single_runs_commands() -> TestResult {
+        for runtime in Runtime::find_on_path() {
+            println!("{:?}", runtime);
+            let data_dir = tempdir::TempDir::new("data")?;
+            let cluster = Cluster::new(&data_dir, runtime);
+            cluster.create()?;
+            cluster.single(&[
+                "ALTER SYSTEM SET fsync = 'on'",
+                "ALTER SYSTEM SET full_page_writes = 'off'",
+            ])?;
+            let conf_auto = std::fs::read_to_string(data_dir.path().join("postgresql.auto.conf"))?;
+            assert!(conf_auto.contains("fsync = 'on'"));
+            assert!(conf_auto.contains("full_page_writes = 'off'"));
+        }
+        Ok(())
     }
 }

--- a/src/coordinate.rs
+++ b/src/coordinate.rs
@@ -12,7 +12,7 @@
 //! let cluster = cluster::Cluster::new(&data_dir, runtime);
 //! let lock_file = cluster_dir.path().join("lock");
 //! let lock = lock::UnlockedFile::try_from(lock_file.as_path()).unwrap();
-//! assert!(coordinate::run_and_stop(&cluster, lock, |_| Ok(()), |cluster| cluster.exists()).unwrap())
+//! assert!(coordinate::run_and_stop(&cluster, lock, |cluster| cluster.exists()).unwrap())
 //! ```
 
 use std::time::Duration;
@@ -30,17 +30,15 @@ use crate::lock;
 /// (maybe) stops the cluster again, and finally returns the result of `action`.
 /// If there are other users of the cluster – i.e. if an exclusive lock cannot
 /// be acquired during the shutdown phase – then the cluster is left running.
-pub fn run_and_stop<'a, INIT, ACTION, T>(
+pub fn run_and_stop<'a, F, T>(
     cluster: &'a Cluster,
     lock: lock::UnlockedFile,
-    initialise: INIT,
-    action: ACTION,
+    action: F,
 ) -> Result<T, ClusterError>
 where
-    INIT: std::panic::UnwindSafe + FnOnce(&'a Cluster) -> Result<(), ClusterError>,
-    ACTION: std::panic::UnwindSafe + FnOnce(&'a Cluster) -> T,
+    F: std::panic::UnwindSafe + FnOnce(&'a Cluster) -> T,
 {
-    let lock = startup(cluster, lock, initialise)?;
+    let lock = startup(cluster, lock)?;
     let action_res = std::panic::catch_unwind(|| action(cluster));
     let _: Option<bool> = shutdown(cluster, lock, |cluster| cluster.stop())?;
     match action_res {
@@ -56,17 +54,15 @@ where
 /// returning. If there are other users of the cluster – i.e. if an exclusive
 /// lock cannot be acquired during the shutdown phase – then the cluster is left
 /// running and is **not** destroyed.
-pub fn run_and_destroy<'a, INIT, ACTION, T>(
+pub fn run_and_destroy<'a, F, T>(
     cluster: &'a Cluster,
     lock: lock::UnlockedFile,
-    initialise: INIT,
-    action: ACTION,
+    action: F,
 ) -> Result<T, ClusterError>
 where
-    INIT: std::panic::UnwindSafe + FnOnce(&'a Cluster) -> Result<(), ClusterError>,
-    ACTION: std::panic::UnwindSafe + FnOnce(&'a Cluster) -> T,
+    F: std::panic::UnwindSafe + FnOnce(&'a Cluster) -> T,
 {
-    let lock = startup(cluster, lock, initialise)?;
+    let lock = startup(cluster, lock)?;
     let action_res = std::panic::catch_unwind(|| action(cluster));
     let shutdown_res = shutdown(cluster, lock, |cluster| cluster.destroy());
     match action_res {
@@ -75,14 +71,10 @@ where
     }
 }
 
-fn startup<'a, INIT>(
-    cluster: &'a Cluster,
+fn startup(
+    cluster: &Cluster,
     mut lock: lock::UnlockedFile,
-    initialise: INIT,
-) -> Result<lock::LockedFileShared, ClusterError>
-where
-    INIT: std::panic::UnwindSafe + FnOnce(&'a Cluster) -> Result<(), ClusterError>,
-{
+) -> Result<lock::LockedFileShared, ClusterError> {
     loop {
         lock = match lock.try_lock_exclusive() {
             Ok(Left(lock)) => {
@@ -93,8 +85,6 @@ where
                 // exclusive lock, so we must check if the cluster is
                 // running _now_, else loop back to the top again.
                 if cluster.running()? {
-                    // Perform post-start initialisation.
-                    initialise(cluster)?;
                     return Ok(lock);
                 } else {
                     // Release all locks then sleep for a random time between
@@ -111,9 +101,7 @@ where
                 }
             }
             Ok(Right(lock)) => {
-                // We have an exclusive lock. Perform pre-start initialisation.
-                initialise(cluster)?;
-                // Now try to start the cluster.
+                // We have an exclusive lock, so try to start the cluster.
                 cluster.start()?;
                 // Once started, downgrade to a shared log.
                 return Ok(lock.lock_shared()?);


### PR DESCRIPTION
In its stead, add command-line options to disable `fsync` and also `full_page_writes`.

Fixes #81 and #82.