### PR TITLE
Detect cluster runtime, the beginnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,4 +41,5 @@ shell-quote = "^0.3.0"
 uuid = { version = "^1.3.0", features = ["v5"] }
 
 [dev-dependencies]
+rand = "0.8.5"
 tempdir = "^0.3.7"

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -150,9 +150,9 @@ impl Cluster {
         // later versions, so here we check for specific codes to avoid
         // masking errors from insufficient permissions or missing
         // executables, for example.
-        let running = match (version.major >= 10, version.major) {
+        let running = match version {
             // PostgreSQL 10.x and later.
-            (true, _) => {
+            version::Version::Post10(_major, _minor) => {
                 // PostgreSQL 10
                 // https://www.postgresql.org/docs/10/static/app-pg-ctl.html
                 match code {
@@ -170,12 +170,12 @@ impl Cluster {
                 }
             }
             // PostgreSQL 9.x only.
-            (false, 9) => {
+            version::Version::Pre10(9, point, _minor) => {
                 // PostgreSQL 9.4+
                 // https://www.postgresql.org/docs/9.4/static/app-pg-ctl.html
                 // https://www.postgresql.org/docs/9.5/static/app-pg-ctl.html
                 // https://www.postgresql.org/docs/9.6/static/app-pg-ctl.html
-                if version.minor >= 4 {
+                if point >= 4 {
                     match code {
                         // 3 means that the data directory is present and
                         // accessible but that the server is not running.
@@ -193,7 +193,7 @@ impl Cluster {
                 // PostgreSQL 9.2+
                 // https://www.postgresql.org/docs/9.2/static/app-pg-ctl.html
                 // https://www.postgresql.org/docs/9.3/static/app-pg-ctl.html
-                else if version.minor >= 2 {
+                else if point >= 2 {
                     match code {
                         // 3 means that the data directory is present and
                         // accessible but that the server is not running OR
@@ -218,7 +218,7 @@ impl Cluster {
                 }
             }
             // All other versions.
-            (_, _) => None,
+            version::Version::Pre10(_major, _point, _minor) => None,
         };
 
         match running {

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -129,7 +129,7 @@ impl Cluster {
     ///
     /// This returns the version from the file named `PG_VERSION` in the data
     /// directory if it exists, otherwise this returns `None`. For PostgreSQL
-    /// versions before 10 this is typically (maybe always) the major and minor
+    /// versions before 10 this is typically (maybe always) the major and point
     /// version, e.g. 9.4 rather than 9.4.26. For version 10 and above it
     /// appears to be just the major number, e.g. 14 rather than 14.2.
     pub fn version(&self) -> Result<Option<version::partial::PartialVersion>, ClusterError> {

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -145,7 +145,7 @@ impl Cluster {
             // More work required to decode what this means.
             Some(code) => code,
         };
-        let version = self.runtime.version()?;
+        let version = self.runtime.version()?.parse()?;
         // PostgreSQL has evolved to return different error codes in
         // later versions, so here we check for specific codes to avoid
         // masking errors from insufficient permissions or missing
@@ -548,7 +548,9 @@ mod tests {
             //   but it won't output it.
             //     -- https://www.postgresql.org/docs/9.4/release-9-4-22.html
             //
-            if runtime.version().unwrap() < Version::from_str("9.4.22").unwrap() {
+            if runtime.version().unwrap().parse::<Version>().unwrap()
+                < Version::from_str("9.4.22").unwrap()
+            {
                 let dealias = |tz: &String| (if tz == "UCT" { "UTC" } else { tz }).to_owned();
                 assert_eq!(params.get("TimeZone").map(dealias), Some("UTC".into()));
                 assert_eq!(params.get("log_timezone").map(dealias), Some("UTC".into()));
@@ -563,7 +565,9 @@ mod tests {
             //   them as read-only server variables was unhelpful.
             //     -- https://www.postgresql.org/docs/16/release-16.html
             //
-            if runtime.version().unwrap() >= Version::from_str("16.0").unwrap() {
+            if runtime.version().unwrap().parse::<Version>().unwrap()
+                >= Version::from_str("16.0").unwrap()
+            {
                 assert_eq!(params.get("lc_collate"), None);
                 assert_eq!(params.get("lc_ctype"), None);
                 // 🚨 Also in PostgreSQL 16, lc_messages is now the empty string

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use clap::Parser;
 use color_eyre::eyre::{bail, Result, WrapErr};
 use color_eyre::{Help, SectionExt};
 
-use postgresfixture::{cluster, coordinate, lock, runtime};
+use postgresfixture::{cluster, coordinate, lock, runtime, version};
 
 fn main() -> Result<()> {
     color_eyre::install()?;
@@ -60,9 +60,12 @@ fn main() -> Result<()> {
             let mut runtimes: Vec<_> = runtimes_on_path
                 .iter()
                 .zip(iter::once(true).chain(iter::repeat(false)))
-                .filter_map(|(runtime, default)| match runtime.version() {
-                    Ok(version) => Some((version, runtime, default)),
-                    Err(_) => None,
+                .filter_map(|(runtime, default)| {
+                    match runtime.version().map(|v| v.parse::<version::Version>()) {
+                        Ok(Ok(version)) => Some((version, runtime, default)),
+                        Ok(Err(_)) => None,
+                        Err(_) => None,
+                    }
                 })
                 .collect();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use clap::Parser;
 use color_eyre::eyre::{bail, Result, WrapErr};
 use color_eyre::{Help, SectionExt};
 
-use postgresfixture::{cluster, coordinate, lock, runtime, version};
+use postgresfixture::{cluster, coordinate, lock, runtime};
 
 fn main() -> Result<()> {
     color_eyre::install()?;
@@ -60,12 +60,9 @@ fn main() -> Result<()> {
             let mut runtimes: Vec<_> = runtimes_on_path
                 .iter()
                 .zip(iter::once(true).chain(iter::repeat(false)))
-                .filter_map(|(runtime, default)| {
-                    match runtime.version().map(|v| v.parse::<version::Version>()) {
-                        Ok(Ok(version)) => Some((version, runtime, default)),
-                        Ok(Err(_)) => None,
-                        Err(_) => None,
-                    }
+                .filter_map(|(runtime, default)| match runtime.version() {
+                    Ok(version) => Some((version, runtime, default)),
+                    Err(_) => None,
                 })
                 .collect();
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -8,11 +8,11 @@
 
 use std::env;
 use std::ffi::OsStr;
+use std::io;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use crate::util;
-use crate::version::{Version, VersionError};
 
 #[derive(Clone, Debug, Default)]
 pub struct Runtime {
@@ -51,18 +51,19 @@ impl Runtime {
         }
     }
 
-    /// Get the version number of PostgreSQL.
+    /// Get the version string of PostgreSQL from `pg_ctl`.
     ///
     /// <https://www.postgresql.org/support/versioning/> shows that version
-    /// numbers are **not** SemVer compatible, so we have to parse them
-    /// ourselves.
-    pub fn version(&self) -> Result<Version, VersionError> {
+    /// numbers are **not** SemVer compatible. The [`version`][`crate::version`]
+    /// module in this crate can parse the version string returned by this
+    /// function.
+    pub fn version(&self) -> Result<String, io::Error> {
         // Execute pg_ctl and extract version.
         let version_output = self.execute("pg_ctl").arg("--version").output()?;
         let version_string = String::from_utf8_lossy(&version_output.stdout);
         // The version parser can deal with leading garbage, i.e. it can parse
         // "pg_ctl (PostgreSQL) 12.2" and get 12.2 out of it.
-        Ok(version_string.parse()?)
+        Ok(version_string.into())
     }
 
     /// Return a [`Command`] prepped to run the given `program` in this

--- a/src/version.rs
+++ b/src/version.rs
@@ -9,7 +9,7 @@
 //! See <https://www.postgresql.org/support/versioning/> for information on
 //! PostgreSQL's versioning scheme.
 
-mod partial;
+pub mod partial;
 
 use std::str::FromStr;
 use std::{error, fmt, num};

--- a/src/version.rs
+++ b/src/version.rs
@@ -9,7 +9,8 @@
 //! See <https://www.postgresql.org/support/versioning/> for information on
 //! PostgreSQL's versioning scheme.
 
-use std::cmp::Ordering;
+mod partial;
+
 use std::str::FromStr;
 use std::{error, fmt, num};
 
@@ -89,126 +90,45 @@ impl FromStr for Version {
     }
 }
 
-#[derive(Debug)]
-pub enum PartialVersion {
-    A(u32, u32, u32),
-    B(u32, u32),
-    C(u32),
-}
-
-impl PartialEq for PartialVersion {
-    fn eq(&self, other: &Self) -> bool {
-        self.partial_cmp(other) == Some(Ordering::Equal)
-    }
-}
-
-impl Eq for PartialVersion {}
-
-impl PartialOrd for PartialVersion {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        use PartialVersion::*;
-        match (self, other) {
-            (A(x1, x2, x3), A(y1, y2, y3)) => (x1, x2, x3).partial_cmp(&(y1, y2, y3)),
-            (A(x1, x2, x3), B(y1, y2)) => (x1, x2, x3).partial_cmp(&(y1, y2, &0)),
-            (A(x1, x2, x3), C(y1)) => (x1, x2, x3).partial_cmp(&(y1, &0, &0)),
-            (B(x1, x2), A(y1, y2, y3)) => (x1, x2, &0).partial_cmp(&(y1, y2, y3)),
-            (B(x1, x2), B(y1, y2)) => (x1, x2).partial_cmp(&(y1, y2)),
-            (B(x1, x2), C(y1)) => (x1, x2).partial_cmp(&(y1, &0)),
-            (C(x1), A(y1, y2, y3)) => (x1, &0, &0).partial_cmp(&(y1, y2, y3)),
-            (C(x1), B(y1, y2)) => (x1, &0).partial_cmp(&(y1, y2)),
-            (C(x1), C(y1)) => x1.partial_cmp(y1),
-        }
-    }
-}
-
-impl Ord for PartialVersion {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        use PartialVersion::*;
-        match (self, other) {
-            (A(x1, x2, x3), A(y1, y2, y3)) => (x1, x2, x3).cmp(&(y1, y2, y3)),
-            (A(x1, x2, x3), B(y1, y2)) => (x1, x2, x3).cmp(&(y1, y2, &0)),
-            (A(x1, x2, x3), C(y1)) => (x1, x2, x3).cmp(&(y1, &0, &0)),
-            (B(x1, x2), A(y1, y2, y3)) => (x1, x2, &0).cmp(&(y1, y2, y3)),
-            (B(x1, x2), B(y1, y2)) => (x1, x2).cmp(&(y1, y2)),
-            (B(x1, x2), C(y1)) => (x1, x2).cmp(&(y1, &0)),
-            (C(x1), A(y1, y2, y3)) => (x1, &0, &0).cmp(&(y1, y2, y3)),
-            (C(x1), B(y1, y2)) => (x1, &0).cmp(&(y1, y2)),
-            (C(x1), C(y1)) => x1.cmp(y1),
-        }
-    }
-}
-
-impl fmt::Display for PartialVersion {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::A(a, b, c) => fmt.pad(&format!("{}.{}.{}", a, b, c)),
-            Self::B(a, b) => fmt.pad(&format!("{}.{}", a, b)),
-            Self::C(a) => fmt.pad(&format!("{}", a)),
-        }
-    }
-}
-
-impl FromStr for PartialVersion {
-    type Err = VersionError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let re = Regex::new(r"(?x) \b (\d+) (?: [.] (\d+) )? (?: [.] (\d+) )? \b").unwrap();
-        match re.captures(s) {
-            Some(caps) => match (
-                caps.get(1).and_then(|n| n.as_str().parse::<u32>().ok()),
-                caps.get(2).and_then(|n| n.as_str().parse::<u32>().ok()),
-                caps.get(3).and_then(|n| n.as_str().parse::<u32>().ok()),
-            ) {
-                (Some(a), Some(b), Some(c)) => Ok(Self::A(a, b, c)),
-                (Some(a), Some(b), _) => Ok(Self::B(a, b)),
-                (Some(a), _, _) => Ok(Self::C(a)),
-                _ => Err(VersionError::BadlyFormed),
-            },
-            None => Err(VersionError::Missing),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    mod version {
-        use super::super::Version::{Post10, Pre10};
-        use super::super::{Version, VersionError::*};
+    use super::Version::{Post10, Pre10};
+    use super::{Version, VersionError::*};
 
-        use std::cmp::Ordering;
+    use std::cmp::Ordering;
 
-        #[test]
-        fn parses_version_below_10() {
-            assert_eq!(Ok(Pre10(9, 6, 17)), "9.6.17".parse());
-        }
+    #[test]
+    fn parses_version_below_10() {
+        assert_eq!(Ok(Pre10(9, 6, 17)), "9.6.17".parse());
+    }
 
-        #[test]
-        fn parses_version_above_10() {
-            assert_eq!(Ok(Post10(12, 2)), "12.2".parse());
-        }
+    #[test]
+    fn parses_version_above_10() {
+        assert_eq!(Ok(Post10(12, 2)), "12.2".parse());
+    }
 
-        #[test]
-        fn parse_returns_error_when_version_is_invalid() {
-            // 4294967295 is (2^32 + 1), so won't fit in a u32.
-            assert_eq!(Err(BadlyFormed), "4294967296.0".parse::<Version>());
-        }
+    #[test]
+    fn parse_returns_error_when_version_is_invalid() {
+        // 4294967295 is (2^32 + 1), so won't fit in a u32.
+        assert_eq!(Err(BadlyFormed), "4294967296.0".parse::<Version>());
+    }
 
-        #[test]
-        fn parse_returns_error_when_version_not_found() {
-            assert_eq!(Err(Missing), "foo".parse::<Version>());
-        }
+    #[test]
+    fn parse_returns_error_when_version_not_found() {
+        assert_eq!(Err(Missing), "foo".parse::<Version>());
+    }
 
-        #[test]
-        fn displays_version_below_10() {
-            assert_eq!("9.6.17", format!("{}", Pre10(9, 6, 17)));
-        }
+    #[test]
+    fn displays_version_below_10() {
+        assert_eq!("9.6.17", format!("{}", Pre10(9, 6, 17)));
+    }
 
-        #[test]
-        fn displays_version_above_10() {
-            assert_eq!("12.2", format!("{}", Post10(12, 2)));
-        }
+    #[test]
+    fn displays_version_above_10() {
+        assert_eq!("12.2", format!("{}", Post10(12, 2)));
+    }
 
-        #[test]
+    #[test]
         #[rustfmt::skip]
         fn derive_partial_ord_works_as_expected() {
             assert_eq!(Pre10(9, 10, 11).partial_cmp(&Post10(10, 11)), Some(Ordering::Less));
@@ -217,132 +137,25 @@ mod tests {
             assert_eq!(Post10(10, 11).partial_cmp(&Post10(10, 11)), Some(Ordering::Equal));
         }
 
-        #[test]
-        fn derive_ord_works_as_expected() {
-            let mut versions = vec![
+    #[test]
+    fn derive_ord_works_as_expected() {
+        let mut versions = vec![
+            Pre10(9, 10, 11),
+            Post10(10, 11),
+            Post10(14, 2),
+            Pre10(9, 10, 12),
+            Post10(10, 12),
+        ];
+        versions.sort(); // Uses `Ord`.
+        assert_eq!(
+            versions,
+            vec![
                 Pre10(9, 10, 11),
-                Post10(10, 11),
-                Post10(14, 2),
                 Pre10(9, 10, 12),
+                Post10(10, 11),
                 Post10(10, 12),
-            ];
-            versions.sort(); // Uses `Ord`.
-            assert_eq!(
-                versions,
-                vec![
-                    Pre10(9, 10, 11),
-                    Pre10(9, 10, 12),
-                    Post10(10, 11),
-                    Post10(10, 12),
-                    Post10(14, 2)
-                ]
-            );
-        }
-    }
-
-    mod partial_version {
-        use super::super::{PartialVersion, PartialVersion::*, VersionError::*};
-
-        use rand::seq::SliceRandom;
-        use rand::thread_rng;
-
-        #[test]
-        fn parses_version_below_10() {
-            assert_eq!(Ok(A(9, 6, 17)), "9.6.17".parse());
-        }
-
-        #[test]
-        fn parses_version_above_10() {
-            assert_eq!(Ok(B(12, 2)), "12.2".parse());
-        }
-
-        #[test]
-        fn parse_returns_error_when_version_is_invalid() {
-            // 4294967295 is (2^32 + 1), so won't fit in a u32.
-            assert_eq!(Err(BadlyFormed), "4294967296.0".parse::<PartialVersion>());
-        }
-
-        #[test]
-        fn parse_returns_error_when_version_not_found() {
-            assert_eq!(Err(Missing), "foo".parse::<PartialVersion>());
-        }
-
-        #[test]
-        fn displays_version_below_10() {
-            assert_eq!("9.6.17", format!("{}", A(9, 6, 17)));
-        }
-
-        #[test]
-        fn displays_version_above_10() {
-            assert_eq!("12.2", format!("{}", B(12, 2)));
-        }
-
-        #[test]
-        fn derive_partial_ord_works_as_expected() {
-            let mut versions = vec![
-                A(9, 10, 11),
-                A(9, 10, 12),
-                B(8, 11),
-                B(9, 11),
-                B(9, 12),
-                B(10, 11),
-                C(8),
-                C(9),
-                C(11),
-            ];
-            let mut rng = thread_rng();
-            for _ in 0..1000 {
-                versions.shuffle(&mut rng);
-                versions.sort_by(|a, b| a.partial_cmp(b).unwrap());
-                assert_eq!(
-                    versions,
-                    vec![
-                        C(8),
-                        B(8, 11),
-                        C(9),
-                        A(9, 10, 11),
-                        A(9, 10, 12),
-                        B(9, 11),
-                        B(9, 12),
-                        B(10, 11),
-                        C(11),
-                    ]
-                );
-            }
-        }
-
-        #[test]
-        fn derive_ord_works_as_expected() {
-            let mut versions = vec![
-                A(9, 10, 11),
-                A(9, 10, 12),
-                B(8, 11),
-                B(9, 11),
-                B(9, 12),
-                B(10, 11),
-                C(8),
-                C(9),
-                C(11),
-            ];
-            let mut rng = thread_rng();
-            for _ in 0..1000 {
-                versions.shuffle(&mut rng);
-                versions.sort();
-                assert_eq!(
-                    versions,
-                    vec![
-                        C(8),
-                        B(8, 11),
-                        C(9),
-                        A(9, 10, 11),
-                        A(9, 10, 12),
-                        B(9, 11),
-                        B(9, 12),
-                        B(10, 11),
-                        C(11),
-                    ]
-                );
-            }
-        }
+                Post10(14, 2)
+            ]
+        );
     }
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -16,7 +16,7 @@ use std::{error, fmt, num};
 
 use regex::Regex;
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Version {
     Pre10(u32, u32, u32),
     Post10(u32, u32),

--- a/src/version.rs
+++ b/src/version.rs
@@ -9,6 +9,7 @@
 //! See <https://www.postgresql.org/support/versioning/> for information on
 //! PostgreSQL's versioning scheme.
 
+use std::cmp::Ordering;
 use std::str::FromStr;
 use std::{error, fmt, num};
 
@@ -88,72 +89,260 @@ impl FromStr for Version {
     }
 }
 
+#[derive(Debug)]
+pub enum PartialVersion {
+    A(u32, u32, u32),
+    B(u32, u32),
+    C(u32),
+}
+
+impl PartialEq for PartialVersion {
+    fn eq(&self, other: &Self) -> bool {
+        self.partial_cmp(other) == Some(Ordering::Equal)
+    }
+}
+
+impl Eq for PartialVersion {}
+
+impl PartialOrd for PartialVersion {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        use PartialVersion::*;
+        match (self, other) {
+            (A(x1, x2, x3), A(y1, y2, y3)) => (x1, x2, x3).partial_cmp(&(y1, y2, y3)),
+            (A(x1, x2, x3), B(y1, y2)) => (x1, x2, x3).partial_cmp(&(y1, y2, &0)),
+            (A(x1, x2, x3), C(y1)) => (x1, x2, x3).partial_cmp(&(y1, &0, &0)),
+            (B(x1, x2), A(y1, y2, y3)) => (x1, x2, &0).partial_cmp(&(y1, y2, y3)),
+            (B(x1, x2), B(y1, y2)) => (x1, x2).partial_cmp(&(y1, y2)),
+            (B(x1, x2), C(y1)) => (x1, x2).partial_cmp(&(y1, &0)),
+            (C(x1), A(y1, y2, y3)) => (x1, &0, &0).partial_cmp(&(y1, y2, y3)),
+            (C(x1), B(y1, y2)) => (x1, &0).partial_cmp(&(y1, y2)),
+            (C(x1), C(y1)) => x1.partial_cmp(y1),
+        }
+    }
+}
+
+impl Ord for PartialVersion {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        use PartialVersion::*;
+        match (self, other) {
+            (A(x1, x2, x3), A(y1, y2, y3)) => (x1, x2, x3).cmp(&(y1, y2, y3)),
+            (A(x1, x2, x3), B(y1, y2)) => (x1, x2, x3).cmp(&(y1, y2, &0)),
+            (A(x1, x2, x3), C(y1)) => (x1, x2, x3).cmp(&(y1, &0, &0)),
+            (B(x1, x2), A(y1, y2, y3)) => (x1, x2, &0).cmp(&(y1, y2, y3)),
+            (B(x1, x2), B(y1, y2)) => (x1, x2).cmp(&(y1, y2)),
+            (B(x1, x2), C(y1)) => (x1, x2).cmp(&(y1, &0)),
+            (C(x1), A(y1, y2, y3)) => (x1, &0, &0).cmp(&(y1, y2, y3)),
+            (C(x1), B(y1, y2)) => (x1, &0).cmp(&(y1, y2)),
+            (C(x1), C(y1)) => x1.cmp(y1),
+        }
+    }
+}
+
+impl fmt::Display for PartialVersion {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::A(a, b, c) => fmt.pad(&format!("{}.{}.{}", a, b, c)),
+            Self::B(a, b) => fmt.pad(&format!("{}.{}", a, b)),
+            Self::C(a) => fmt.pad(&format!("{}", a)),
+        }
+    }
+}
+
+impl FromStr for PartialVersion {
+    type Err = VersionError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let re = Regex::new(r"(?x) \b (\d+) (?: [.] (\d+) )? (?: [.] (\d+) )? \b").unwrap();
+        match re.captures(s) {
+            Some(caps) => match (
+                caps.get(1).and_then(|n| n.as_str().parse::<u32>().ok()),
+                caps.get(2).and_then(|n| n.as_str().parse::<u32>().ok()),
+                caps.get(3).and_then(|n| n.as_str().parse::<u32>().ok()),
+            ) {
+                (Some(a), Some(b), Some(c)) => Ok(Self::A(a, b, c)),
+                (Some(a), Some(b), _) => Ok(Self::B(a, b)),
+                (Some(a), _, _) => Ok(Self::C(a)),
+                _ => Err(VersionError::BadlyFormed),
+            },
+            None => Err(VersionError::Missing),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::Version::{Post10, Pre10};
-    use super::{Version, VersionError::*};
+    mod version {
+        use super::super::Version::{Post10, Pre10};
+        use super::super::{Version, VersionError::*};
 
-    use std::cmp::Ordering;
+        use std::cmp::Ordering;
 
-    #[test]
-    fn parses_version_below_10() {
-        assert_eq!(Ok(Pre10(9, 6, 17)), "9.6.17".parse());
-    }
+        #[test]
+        fn parses_version_below_10() {
+            assert_eq!(Ok(Pre10(9, 6, 17)), "9.6.17".parse());
+        }
 
-    #[test]
-    fn parses_version_above_10() {
-        assert_eq!(Ok(Post10(12, 2)), "12.2".parse());
-    }
+        #[test]
+        fn parses_version_above_10() {
+            assert_eq!(Ok(Post10(12, 2)), "12.2".parse());
+        }
 
-    #[test]
-    fn parse_returns_error_when_version_is_invalid() {
-        // 4294967295 is (2^32 + 1), so won't fit in a u32.
-        assert_eq!(Err(BadlyFormed), "4294967296.0".parse::<Version>());
-    }
+        #[test]
+        fn parse_returns_error_when_version_is_invalid() {
+            // 4294967295 is (2^32 + 1), so won't fit in a u32.
+            assert_eq!(Err(BadlyFormed), "4294967296.0".parse::<Version>());
+        }
 
-    #[test]
-    fn parse_returns_error_when_version_not_found() {
-        assert_eq!(Err(Missing), "foo".parse::<Version>());
-    }
+        #[test]
+        fn parse_returns_error_when_version_not_found() {
+            assert_eq!(Err(Missing), "foo".parse::<Version>());
+        }
 
-    #[test]
-    fn displays_version_below_10() {
-        assert_eq!("9.6.17", format!("{}", Pre10(9, 6, 17)));
-    }
+        #[test]
+        fn displays_version_below_10() {
+            assert_eq!("9.6.17", format!("{}", Pre10(9, 6, 17)));
+        }
 
-    #[test]
-    fn displays_version_above_10() {
-        assert_eq!("12.2", format!("{}", Post10(12, 2)));
-    }
+        #[test]
+        fn displays_version_above_10() {
+            assert_eq!("12.2", format!("{}", Post10(12, 2)));
+        }
 
-    #[test]
-    #[rustfmt::skip]
-    fn derive_partial_ord_works_as_expected() {
-        assert_eq!(Pre10(9, 10, 11).partial_cmp(&Post10(10, 11)), Some(Ordering::Less));
-        assert_eq!(Post10(10, 11).partial_cmp(&Pre10(9, 10, 11)), Some(Ordering::Greater));
-        assert_eq!(Pre10(9, 10, 11).partial_cmp(&Pre10(9, 10, 11)), Some(Ordering::Equal));
-        assert_eq!(Post10(10, 11).partial_cmp(&Post10(10, 11)), Some(Ordering::Equal));
-    }
+        #[test]
+        #[rustfmt::skip]
+        fn derive_partial_ord_works_as_expected() {
+            assert_eq!(Pre10(9, 10, 11).partial_cmp(&Post10(10, 11)), Some(Ordering::Less));
+            assert_eq!(Post10(10, 11).partial_cmp(&Pre10(9, 10, 11)), Some(Ordering::Greater));
+            assert_eq!(Pre10(9, 10, 11).partial_cmp(&Pre10(9, 10, 11)), Some(Ordering::Equal));
+            assert_eq!(Post10(10, 11).partial_cmp(&Post10(10, 11)), Some(Ordering::Equal));
+        }
 
-    #[test]
-    fn derive_ord_works_as_expected() {
-        let mut versions = vec![
-            Pre10(9, 10, 11),
-            Post10(10, 11),
-            Post10(14, 2),
-            Pre10(9, 10, 12),
-            Post10(10, 12),
-        ];
-        versions.sort(); // Uses `Ord`.
-        assert_eq!(
-            versions,
-            vec![
+        #[test]
+        fn derive_ord_works_as_expected() {
+            let mut versions = vec![
                 Pre10(9, 10, 11),
-                Pre10(9, 10, 12),
                 Post10(10, 11),
+                Post10(14, 2),
+                Pre10(9, 10, 12),
                 Post10(10, 12),
-                Post10(14, 2)
-            ]
-        );
+            ];
+            versions.sort(); // Uses `Ord`.
+            assert_eq!(
+                versions,
+                vec![
+                    Pre10(9, 10, 11),
+                    Pre10(9, 10, 12),
+                    Post10(10, 11),
+                    Post10(10, 12),
+                    Post10(14, 2)
+                ]
+            );
+        }
+    }
+
+    mod partial_version {
+        use super::super::{PartialVersion, PartialVersion::*, VersionError::*};
+
+        use rand::seq::SliceRandom;
+        use rand::thread_rng;
+
+        #[test]
+        fn parses_version_below_10() {
+            assert_eq!(Ok(A(9, 6, 17)), "9.6.17".parse());
+        }
+
+        #[test]
+        fn parses_version_above_10() {
+            assert_eq!(Ok(B(12, 2)), "12.2".parse());
+        }
+
+        #[test]
+        fn parse_returns_error_when_version_is_invalid() {
+            // 4294967295 is (2^32 + 1), so won't fit in a u32.
+            assert_eq!(Err(BadlyFormed), "4294967296.0".parse::<PartialVersion>());
+        }
+
+        #[test]
+        fn parse_returns_error_when_version_not_found() {
+            assert_eq!(Err(Missing), "foo".parse::<PartialVersion>());
+        }
+
+        #[test]
+        fn displays_version_below_10() {
+            assert_eq!("9.6.17", format!("{}", A(9, 6, 17)));
+        }
+
+        #[test]
+        fn displays_version_above_10() {
+            assert_eq!("12.2", format!("{}", B(12, 2)));
+        }
+
+        #[test]
+        fn derive_partial_ord_works_as_expected() {
+            let mut versions = vec![
+                A(9, 10, 11),
+                A(9, 10, 12),
+                B(8, 11),
+                B(9, 11),
+                B(9, 12),
+                B(10, 11),
+                C(8),
+                C(9),
+                C(11),
+            ];
+            let mut rng = thread_rng();
+            for _ in 0..1000 {
+                versions.shuffle(&mut rng);
+                versions.sort_by(|a, b| a.partial_cmp(b).unwrap());
+                assert_eq!(
+                    versions,
+                    vec![
+                        C(8),
+                        B(8, 11),
+                        C(9),
+                        A(9, 10, 11),
+                        A(9, 10, 12),
+                        B(9, 11),
+                        B(9, 12),
+                        B(10, 11),
+                        C(11),
+                    ]
+                );
+            }
+        }
+
+        #[test]
+        fn derive_ord_works_as_expected() {
+            let mut versions = vec![
+                A(9, 10, 11),
+                A(9, 10, 12),
+                B(8, 11),
+                B(9, 11),
+                B(9, 12),
+                B(10, 11),
+                C(8),
+                C(9),
+                C(11),
+            ];
+            let mut rng = thread_rng();
+            for _ in 0..1000 {
+                versions.shuffle(&mut rng);
+                versions.sort();
+                assert_eq!(
+                    versions,
+                    vec![
+                        C(8),
+                        B(8, 11),
+                        C(9),
+                        A(9, 10, 11),
+                        A(9, 10, 12),
+                        B(9, 11),
+                        B(9, 12),
+                        B(10, 11),
+                        C(11),
+                    ]
+                );
+            }
+        }
     }
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -16,9 +16,20 @@ use std::{error, fmt, num};
 
 use regex::Regex;
 
+/// Represents a full PostgreSQL version. This is the kind of thing we see when
+/// running `pg_ctl --version` for example.
+///
+/// The "Current minor" column shown on the [PostgreSQL "Versioning Policy"
+/// page][versioning] is what this models.
+///
+/// [versioning]: https://www.postgresql.org/support/versioning/
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Version {
+    /// Pre-PostgreSQL 10, with major, point, and minor version numbers, e.g.
+    /// 9.6.17. It is an error to create this variant with a major number >= 10.
     Pre10(u32, u32, u32),
+    /// PostgreSQL 10+, with major and minor version number, e.g. 10.3. It is an
+    /// error to create this variant with a major number < 10.
     Post10(u32, u32),
 }
 

--- a/src/version/partial.rs
+++ b/src/version/partial.rs
@@ -1,0 +1,195 @@
+use std::cmp::Ordering;
+use std::fmt;
+use std::str::FromStr;
+
+use regex::Regex;
+
+use super::VersionError;
+
+#[derive(Debug)]
+pub enum PartialVersion {
+    A(u32, u32, u32),
+    B(u32, u32),
+    C(u32),
+}
+
+impl PartialEq for PartialVersion {
+    fn eq(&self, other: &Self) -> bool {
+        self.partial_cmp(other) == Some(Ordering::Equal)
+    }
+}
+
+impl Eq for PartialVersion {}
+
+impl PartialOrd for PartialVersion {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        use PartialVersion::*;
+        match (self, other) {
+            (A(x1, x2, x3), A(y1, y2, y3)) => (x1, x2, x3).partial_cmp(&(y1, y2, y3)),
+            (A(x1, x2, x3), B(y1, y2)) => (x1, x2, x3).partial_cmp(&(y1, y2, &0)),
+            (A(x1, x2, x3), C(y1)) => (x1, x2, x3).partial_cmp(&(y1, &0, &0)),
+            (B(x1, x2), A(y1, y2, y3)) => (x1, x2, &0).partial_cmp(&(y1, y2, y3)),
+            (B(x1, x2), B(y1, y2)) => (x1, x2).partial_cmp(&(y1, y2)),
+            (B(x1, x2), C(y1)) => (x1, x2).partial_cmp(&(y1, &0)),
+            (C(x1), A(y1, y2, y3)) => (x1, &0, &0).partial_cmp(&(y1, y2, y3)),
+            (C(x1), B(y1, y2)) => (x1, &0).partial_cmp(&(y1, y2)),
+            (C(x1), C(y1)) => x1.partial_cmp(y1),
+        }
+    }
+}
+
+impl Ord for PartialVersion {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        use PartialVersion::*;
+        match (self, other) {
+            (A(x1, x2, x3), A(y1, y2, y3)) => (x1, x2, x3).cmp(&(y1, y2, y3)),
+            (A(x1, x2, x3), B(y1, y2)) => (x1, x2, x3).cmp(&(y1, y2, &0)),
+            (A(x1, x2, x3), C(y1)) => (x1, x2, x3).cmp(&(y1, &0, &0)),
+            (B(x1, x2), A(y1, y2, y3)) => (x1, x2, &0).cmp(&(y1, y2, y3)),
+            (B(x1, x2), B(y1, y2)) => (x1, x2).cmp(&(y1, y2)),
+            (B(x1, x2), C(y1)) => (x1, x2).cmp(&(y1, &0)),
+            (C(x1), A(y1, y2, y3)) => (x1, &0, &0).cmp(&(y1, y2, y3)),
+            (C(x1), B(y1, y2)) => (x1, &0).cmp(&(y1, y2)),
+            (C(x1), C(y1)) => x1.cmp(y1),
+        }
+    }
+}
+
+impl fmt::Display for PartialVersion {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::A(a, b, c) => fmt.pad(&format!("{}.{}.{}", a, b, c)),
+            Self::B(a, b) => fmt.pad(&format!("{}.{}", a, b)),
+            Self::C(a) => fmt.pad(&format!("{}", a)),
+        }
+    }
+}
+
+impl FromStr for PartialVersion {
+    type Err = VersionError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let re = Regex::new(r"(?x) \b (\d+) (?: [.] (\d+) )? (?: [.] (\d+) )? \b").unwrap();
+        match re.captures(s) {
+            Some(caps) => match (
+                caps.get(1).and_then(|n| n.as_str().parse::<u32>().ok()),
+                caps.get(2).and_then(|n| n.as_str().parse::<u32>().ok()),
+                caps.get(3).and_then(|n| n.as_str().parse::<u32>().ok()),
+            ) {
+                (Some(a), Some(b), Some(c)) => Ok(Self::A(a, b, c)),
+                (Some(a), Some(b), _) => Ok(Self::B(a, b)),
+                (Some(a), _, _) => Ok(Self::C(a)),
+                _ => Err(VersionError::BadlyFormed),
+            },
+            None => Err(VersionError::Missing),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::VersionError::*;
+    use super::{PartialVersion, PartialVersion::*};
+
+    use rand::seq::SliceRandom;
+    use rand::thread_rng;
+
+    #[test]
+    fn parses_version_below_10() {
+        assert_eq!(Ok(A(9, 6, 17)), "9.6.17".parse());
+    }
+
+    #[test]
+    fn parses_version_above_10() {
+        assert_eq!(Ok(B(12, 2)), "12.2".parse());
+    }
+
+    #[test]
+    fn parse_returns_error_when_version_is_invalid() {
+        // 4294967295 is (2^32 + 1), so won't fit in a u32.
+        assert_eq!(Err(BadlyFormed), "4294967296.0".parse::<PartialVersion>());
+    }
+
+    #[test]
+    fn parse_returns_error_when_version_not_found() {
+        assert_eq!(Err(Missing), "foo".parse::<PartialVersion>());
+    }
+
+    #[test]
+    fn displays_version_below_10() {
+        assert_eq!("9.6.17", format!("{}", A(9, 6, 17)));
+    }
+
+    #[test]
+    fn displays_version_above_10() {
+        assert_eq!("12.2", format!("{}", B(12, 2)));
+    }
+
+    #[test]
+    fn derive_partial_ord_works_as_expected() {
+        let mut versions = vec![
+            A(9, 10, 11),
+            A(9, 10, 12),
+            B(8, 11),
+            B(9, 11),
+            B(9, 12),
+            B(10, 11),
+            C(8),
+            C(9),
+            C(11),
+        ];
+        let mut rng = thread_rng();
+        for _ in 0..1000 {
+            versions.shuffle(&mut rng);
+            versions.sort_by(|a, b| a.partial_cmp(b).unwrap());
+            assert_eq!(
+                versions,
+                vec![
+                    C(8),
+                    B(8, 11),
+                    C(9),
+                    A(9, 10, 11),
+                    A(9, 10, 12),
+                    B(9, 11),
+                    B(9, 12),
+                    B(10, 11),
+                    C(11),
+                ]
+            );
+        }
+    }
+
+    #[test]
+    fn derive_ord_works_as_expected() {
+        let mut versions = vec![
+            A(9, 10, 11),
+            A(9, 10, 12),
+            B(8, 11),
+            B(9, 11),
+            B(9, 12),
+            B(10, 11),
+            C(8),
+            C(9),
+            C(11),
+        ];
+        let mut rng = thread_rng();
+        for _ in 0..1000 {
+            versions.shuffle(&mut rng);
+            versions.sort();
+            assert_eq!(
+                versions,
+                vec![
+                    C(8),
+                    B(8, 11),
+                    C(9),
+                    A(9, 10, 11),
+                    A(9, 10, 12),
+                    B(9, 11),
+                    B(9, 12),
+                    B(10, 11),
+                    C(11),
+                ]
+            );
+        }
+    }
+}

--- a/src/version/partial.rs
+++ b/src/version/partial.rs
@@ -69,7 +69,7 @@ impl FromStr for PartialVersion {
     type Err = VersionError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let re = Regex::new(r"(?x) \b (\d+) (?: [.] (\d+) )? (?: [.] (\d+) )? \b").unwrap();
+        let re = Regex::new(r"(?x) \b (\d+) (?: [.] (\d+) (?: [.] (\d+) )? )? \b").unwrap();
         match re.captures(s) {
             Some(caps) => match (
                 caps.get(1).and_then(|n| n.as_str().parse::<u32>().ok()),

--- a/src/version/partial.rs
+++ b/src/version/partial.rs
@@ -8,12 +8,28 @@ use super::{Version, VersionError};
 
 #[derive(Copy, Clone, Debug)]
 pub enum PartialVersion {
-    /// Major, Minor, Patch.
-    Mmp(u32, u32, u32),
-    /// Major, Minor.
-    Mm(u32, u32),
-    /// Major.
-    M(u32),
+    Pre10m(u32, u32),
+    Pre10mm(u32, u32, u32),
+    Post10m(u32),
+    Post10mm(u32, u32),
+}
+
+/// Convert a [`PartialVersion`] into a [`Version`] that's useful for
+/// comparisons.
+///
+/// The [`Version`] returned has 0 (zero) in the place of the missing parts. For
+/// example, a partial version of `9.6.*` becomes `9.6.0`, and `12.*` becomes
+/// `12.0`.
+impl From<&PartialVersion> for Version {
+    fn from(partial: &PartialVersion) -> Self {
+        use PartialVersion::*;
+        match *partial {
+            Pre10m(a, b) => Version::Pre10(a, b, 0),
+            Pre10mm(a, b, c) => Version::Pre10(a, b, c),
+            Post10m(a) => Version::Post10(a, 0),
+            Post10mm(a, b) => Version::Post10(a, b),
+        }
+    }
 }
 
 impl PartialVersion {
@@ -22,35 +38,30 @@ impl PartialVersion {
     /// Put another way: can a server of the given [`Version`] be used to run a
     /// cluster of this [`PartialVersion`]?
     ///
-    /// This is an interesting question to answer, because clusters contain a
-    /// file named `PG_VERSION` which containing the major version number of the
-    /// cluster's files, e.g. "15" or "9.6".
+    /// This is an interesting question to answer because clusters contain a
+    /// file named `PG_VERSION` which containing just the major version
+    /// number/numbers of the cluster's files, e.g. "15" or "9.6".
     ///
     /// For versions of PostgreSQL before 10, this means that the given
-    /// version's major and minor numbers must match exactly, and the patch
-    /// number must be greater than or equal to this `PartialVersion`'s patch
-    /// number. When this `PartialVersion` has no minor or patch number, the
-    /// given version is assumed to be compatible.
+    /// version's major numbers must match exactly, and the patch number must be
+    /// greater than or equal to this `PartialVersion`'s patch number. When this
+    /// `PartialVersion` has no minor or patch number, the given version is
+    /// assumed to be compatible.
     ///
     /// For versions of PostgreSQL after and including 10, this means that the
     /// given version's major number must match exactly, and the minor number
     /// must be greater than or equal to this `PartialVersion`'s minor number.
     /// When this `PartialVersion` has no minor number, the given version is
-    /// assumed to be compatible. The patch number is ignored.
+    /// assumed to be compatible.
     #[allow(dead_code)]
     pub fn compatible(&self, version: Version) -> bool {
         use PartialVersion::*;
-        match version {
-            Version::Pre10(va, vb, vc) => match *self {
-                Mmp(a, b, c) => a == va && b == vb && c <= vc,
-                Mm(a, b) => a == va && b == vb,
-                M(a) => a == va,
-            },
-            Version::Post10(va, vb) => match *self {
-                Mmp(a, b, _) => a == va && b <= vb,
-                Mm(a, b) => a == va && b <= vb,
-                M(a) => a == va,
-            },
+        match (*self, version) {
+            (Pre10m(a, b), Version::Pre10(x, y, _)) => a == x && b == y,
+            (Pre10mm(a, b, c), Version::Pre10(x, y, z)) => a == x && b == y && c <= z,
+            (Post10m(a), Version::Post10(x, _)) => a == x,
+            (Post10mm(a, b), Version::Post10(x, y)) => a == x && b <= y,
+            _ => false,
         }
     }
 
@@ -64,9 +75,10 @@ impl PartialVersion {
     pub fn sort_key(&self) -> (u32, Option<u32>, Option<u32>) {
         use PartialVersion::*;
         match *self {
-            Mmp(a, b, c) => (a, Some(b), Some(c)),
-            Mm(a, b) => (a, Some(b), None),
-            M(a) => (a, None, None),
+            Pre10m(a, b) => (a, Some(b), None),
+            Pre10mm(a, b, c) => (a, Some(b), Some(c)),
+            Post10m(a) => (a, None, None),
+            Post10mm(a, b) => (a, Some(b), None),
         }
     }
 }
@@ -81,25 +93,36 @@ impl PartialOrd for PartialVersion {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         use PartialVersion::*;
         match (*self, *other) {
-            (Mmp(x1, x2, x3), Mmp(y1, y2, y3)) => (x1, x2, x3).partial_cmp(&(y1, y2, y3)),
-            (Mmp(x1, x2, x3), Mm(y1, y2)) => (x1, x2, x3).partial_cmp(&(y1, y2, 0)),
-            (Mmp(x1, x2, x3), M(y1)) => (x1, x2, x3).partial_cmp(&(y1, 0, 0)),
-            (Mm(x1, x2), Mmp(y1, y2, y3)) => (x1, x2, 0).partial_cmp(&(y1, y2, y3)),
-            (Mm(x1, x2), Mm(y1, y2)) => (x1, x2).partial_cmp(&(y1, y2)),
-            (Mm(x1, x2), M(y1)) => (x1, x2).partial_cmp(&(y1, 0)),
-            (M(x1), Mmp(y1, y2, y3)) => (x1, 0, 0).partial_cmp(&(y1, y2, y3)),
-            (M(x1), Mm(y1, y2)) => (x1, 0).partial_cmp(&(y1, y2)),
-            (M(x1), M(y1)) => x1.partial_cmp(&y1),
+            (Pre10m(a, b), Pre10m(x, y)) => Some((a, b).cmp(&(x, y))),
+            (Pre10m(a, b), Pre10mm(x, y, _)) => Some((a, b).cmp(&(x, y))),
+            (Pre10mm(a, b, _), Pre10m(x, y)) => Some((a, b).cmp(&(x, y))),
+            (Pre10mm(a, b, c), Pre10mm(x, y, z)) => Some((a, b, c).cmp(&(x, y, z))),
+
+            (Post10m(a), Post10m(x)) => Some(a.cmp(&x)),
+            (Post10m(a), Post10mm(x, _)) => Some(a.cmp(&x)),
+            (Post10mm(a, _), Post10m(x)) => Some(a.cmp(&x)),
+            (Post10mm(a, b), Post10mm(x, y)) => Some((a, b).cmp(&(x, y))),
+
+            (Pre10m(..), Post10m(..)) => Some(Ordering::Less),
+            (Pre10m(..), Post10mm(..)) => Some(Ordering::Less),
+            (Pre10mm(..), Post10m(..)) => Some(Ordering::Less),
+            (Pre10mm(..), Post10mm(..)) => Some(Ordering::Less),
+
+            (Post10m(..), Pre10m(..)) => Some(Ordering::Greater),
+            (Post10m(..), Pre10mm(..)) => Some(Ordering::Greater),
+            (Post10mm(..), Pre10m(..)) => Some(Ordering::Greater),
+            (Post10mm(..), Pre10mm(..)) => Some(Ordering::Greater),
         }
     }
 }
 
 impl fmt::Display for PartialVersion {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::Mmp(a, b, c) => fmt.pad(&format!("{}.{}.{}", a, b, c)),
-            Self::Mm(a, b) => fmt.pad(&format!("{}.{}", a, b)),
-            Self::M(a) => fmt.pad(&format!("{}", a)),
+        match *self {
+            Self::Pre10m(a, b) => fmt.pad(&format!("{a}.{b}.*")),
+            Self::Pre10mm(a, b, c) => fmt.pad(&format!("{a}.{b}.{c}")),
+            Self::Post10m(a) => fmt.pad(&format!("{a}.*")),
+            Self::Post10mm(a, b) => fmt.pad(&format!("{a}.{b}")),
         }
     }
 }
@@ -115,9 +138,10 @@ impl FromStr for PartialVersion {
                 caps.get(2).and_then(|n| n.as_str().parse::<u32>().ok()),
                 caps.get(3).and_then(|n| n.as_str().parse::<u32>().ok()),
             ) {
-                (Some(a), Some(b), Some(c)) => Ok(Self::Mmp(a, b, c)),
-                (Some(a), Some(b), _) => Ok(Self::Mm(a, b)),
-                (Some(a), _, _) => Ok(Self::M(a)),
+                (Some(a), Some(b), None) if a < 10 => Ok(Self::Pre10m(a, b)),
+                (Some(a), Some(b), Some(c)) if a < 10 => Ok(Self::Pre10mm(a, b, c)),
+                (Some(a), None, None) if a >= 10 => Ok(Self::Post10m(a)),
+                (Some(a), Some(b), None) if a >= 10 => Ok(Self::Post10mm(a, b)),
                 _ => Err(VersionError::BadlyFormed),
             },
             None => Err(VersionError::Missing),
@@ -135,18 +159,24 @@ mod tests {
 
     #[test]
     fn parses_version_below_10() {
-        assert_eq!(Ok(Mmp(9, 6, 17)), "9.6.17".parse());
+        assert_eq!(Ok(Pre10mm(9, 6, 17)), "9.6.17".parse());
+        assert_eq!(Ok(Pre10m(9, 6)), "9.6".parse());
     }
 
     #[test]
     fn parses_version_above_10() {
-        assert_eq!(Ok(Mm(12, 2)), "12.2".parse());
+        assert_eq!(Ok(Post10mm(12, 2)), "12.2".parse());
+        assert_eq!(Ok(Post10m(12)), "12".parse());
     }
 
     #[test]
     fn parse_returns_error_when_version_is_invalid() {
         // 4294967295 is (2^32 + 1), so won't fit in a u32.
         assert_eq!(Err(BadlyFormed), "4294967296.0".parse::<PartialVersion>());
+        // Before version 10, there are always at least two parts in a version.
+        assert_eq!(Err(BadlyFormed), "9".parse::<PartialVersion>());
+        // From version 10 onwards, there are only two parts in a version.
+        assert_eq!(Err(BadlyFormed), "10.10.10".parse::<PartialVersion>());
     }
 
     #[test]
@@ -156,54 +186,68 @@ mod tests {
 
     #[test]
     fn displays_version_below_10() {
-        assert_eq!("9.6.17", format!("{}", Mmp(9, 6, 17)));
+        assert_eq!("9.6.17", format!("{}", Pre10mm(9, 6, 17)));
+        assert_eq!("9.6.*", format!("{}", Pre10m(9, 6)));
     }
 
     #[test]
     fn displays_version_above_10() {
-        assert_eq!("12.2", format!("{}", Mm(12, 2)));
+        assert_eq!("12.2", format!("{}", Post10mm(12, 2)));
+        assert_eq!("12.*", format!("{}", Post10m(12)));
     }
 
     #[test]
     fn compatible_below_10() {
-        assert!(Mmp(9, 6, 17).compatible("9.6.17".parse().unwrap()));
-        assert!(Mm(9, 6).compatible("9.6.17".parse().unwrap()));
-        assert!(M(9).compatible("9.6.17".parse().unwrap()));
+        let version = "9.6.16".parse().unwrap();
+        assert!(Pre10mm(9, 6, 16).compatible(version));
+        assert!(Pre10m(9, 6).compatible(version));
     }
 
     #[test]
     fn not_compatible_below_10() {
-        assert!(!Mmp(9, 6, 17).compatible("9.6.16".parse().unwrap()));
-        assert!(!Mm(9, 6).compatible("9.5.17".parse().unwrap()));
-        assert!(!M(9).compatible("8.6.17".parse().unwrap()));
+        let version = "9.6.16".parse().unwrap();
+        assert!(!Pre10mm(9, 6, 17).compatible(version));
+        assert!(!Pre10m(9, 7).compatible(version));
+        assert!(!Pre10mm(8, 6, 16).compatible(version));
+        assert!(!Pre10m(8, 6).compatible(version));
     }
 
     #[test]
     fn compatible_above_10() {
-        assert!(Mmp(12, 6, 1234).compatible("12.6".parse().unwrap()));
-        assert!(Mm(13, 2).compatible("13.2".parse().unwrap()));
-        assert!(M(14).compatible("14.7".parse().unwrap()));
+        let version = "12.6".parse().unwrap();
+        assert!(Post10mm(12, 6).compatible(version));
+        assert!(Post10m(12).compatible(version));
     }
 
     #[test]
     fn not_compatible_above_10() {
-        assert!(!Mmp(12, 6, 1234).compatible("12.5".parse().unwrap()));
-        assert!(!Mm(13, 2).compatible("13.1".parse().unwrap()));
-        assert!(!M(14).compatible("13.7".parse().unwrap()));
+        let version = "12.6".parse().unwrap();
+        assert!(!Post10mm(12, 7).compatible(version));
+        assert!(!Post10m(13).compatible(version));
+        assert!(!Post10mm(11, 6).compatible(version));
+        assert!(!Post10m(11).compatible(version));
+    }
+
+    #[test]
+    fn not_compatible_below_10_with_above_10() {
+        let version = "12.6".parse().unwrap();
+        assert!(!Pre10m(9, 1).compatible(version));
+        assert!(!Pre10mm(9, 1, 2).compatible(version));
+        let version = "9.1.2".parse().unwrap();
+        assert!(!Post10m(12).compatible(version));
+        assert!(!Post10mm(12, 6).compatible(version));
     }
 
     #[test]
     fn partial_ord_works_as_expected() {
         let mut versions = vec![
-            Mmp(9, 10, 11),
-            Mmp(9, 10, 12),
-            Mm(8, 11),
-            Mm(9, 11),
-            Mm(9, 12),
-            Mm(10, 11),
-            M(8),
-            M(9),
-            M(11),
+            Pre10mm(9, 10, 11),
+            Pre10mm(9, 10, 12),
+            Pre10m(8, 11),
+            Pre10m(9, 11),
+            Pre10m(9, 12),
+            Post10mm(10, 11),
+            Post10m(11),
         ];
         let mut rng = thread_rng();
         for _ in 0..1000 {
@@ -212,15 +256,13 @@ mod tests {
             assert_eq!(
                 versions,
                 vec![
-                    M(8),
-                    Mm(8, 11),
-                    M(9),
-                    Mmp(9, 10, 11),
-                    Mmp(9, 10, 12),
-                    Mm(9, 11),
-                    Mm(9, 12),
-                    Mm(10, 11),
-                    M(11),
+                    Pre10m(8, 11),
+                    Pre10mm(9, 10, 11),
+                    Pre10mm(9, 10, 12),
+                    Pre10m(9, 11),
+                    Pre10m(9, 12),
+                    Post10mm(10, 11),
+                    Post10m(11),
                 ]
             );
         }
@@ -229,17 +271,15 @@ mod tests {
     #[test]
     fn sort_key_works_as_expected() {
         let mut versions = vec![
-            Mmp(9, 0, 0),
-            Mmp(9, 10, 11),
-            Mmp(9, 10, 12),
-            Mm(9, 0),
-            Mm(8, 11),
-            Mm(9, 11),
-            Mm(9, 12),
-            Mm(10, 11),
-            M(8),
-            M(9),
-            M(11),
+            Pre10mm(9, 0, 0),
+            Pre10mm(9, 10, 11),
+            Pre10mm(9, 10, 12),
+            Pre10m(9, 0),
+            Pre10m(8, 11),
+            Pre10m(9, 11),
+            Pre10m(9, 12),
+            Post10mm(10, 11),
+            Post10m(11),
         ];
         let mut rng = thread_rng();
         for _ in 0..1000 {
@@ -248,17 +288,15 @@ mod tests {
             assert_eq!(
                 versions,
                 vec![
-                    M(8),
-                    Mm(8, 11),
-                    M(9),
-                    Mm(9, 0),
-                    Mmp(9, 0, 0),
-                    Mmp(9, 10, 11),
-                    Mmp(9, 10, 12),
-                    Mm(9, 11),
-                    Mm(9, 12),
-                    Mm(10, 11),
-                    M(11),
+                    Pre10m(8, 11),
+                    Pre10m(9, 0),
+                    Pre10mm(9, 0, 0),
+                    Pre10mm(9, 10, 11),
+                    Pre10mm(9, 10, 12),
+                    Pre10m(9, 11),
+                    Pre10m(9, 12),
+                    Post10mm(10, 11),
+                    Post10m(11),
                 ]
             );
         }

--- a/src/version/partial.rs
+++ b/src/version/partial.rs
@@ -8,14 +8,20 @@ use super::{Version, VersionError};
 
 /// Represents a PostgreSQL version with some parts missing. This is the kind of
 /// thing we might find in a cluster's `PG_VERSION` file.
+///
+/// The "Version" column on the [PostgreSQL "Versioning Policy"
+/// page][versioning] is roughly what this models, but this can also optionally
+/// represent the "Current minor" column too.
+///
+/// [versioning]: https://www.postgresql.org/support/versioning/
 #[derive(Copy, Clone, Debug)]
 pub enum PartialVersion {
-    /// Pre-PostgreSQL 10, with major and minor version numbers, e.g. 9.6. It is
+    /// Pre-PostgreSQL 10, with major and point version numbers, e.g. 9.6. It is
     /// an error to create this variant with a major number >= 10; see
     /// [`checked`][`Self::checked`] for a way to guard against this.
     Pre10m(u32, u32),
-    /// Pre-PostgreSQL 10, with major, minor, and patch version numbers, e.g.
-    /// 9.6.17. It is an error to create this variant with a major number >= 10;
+    /// Pre-PostgreSQL 10, with major, point, and minor version numbers, e.g.
+    /// 9.6.17. It is an error to create this variant with a major number >=§ 10;
     /// see [`checked`][`Self::checked`] for a way to guard against this.
     Pre10mm(u32, u32, u32),
     /// PostgreSQL 10+, with major version number, e.g. 10. It is an error to
@@ -94,14 +100,15 @@ impl PartialVersion {
     /// cluster of this [`PartialVersion`]?
     ///
     /// This is an interesting question to answer because clusters contain a
-    /// file named `PG_VERSION` which containing just the major version
-    /// number/numbers of the cluster's files, e.g. "15" or "9.6".
+    /// file named `PG_VERSION` which containing just the major version number
+    /// of the cluster's files, e.g. "15", or the major.point number for older
+    /// PostgreSQL releases, e.g. "9.6".
     ///
     /// For versions of PostgreSQL before 10, this means that the given
-    /// version's major numbers must match exactly, and the patch number must be
-    /// greater than or equal to this `PartialVersion`'s patch number. When this
-    /// `PartialVersion` has no minor or patch number, the given version is
-    /// assumed to be compatible.
+    /// version's major and point numbers must match exactly, and the minor
+    /// number must be greater than or equal to this `PartialVersion`'s minor
+    /// number. When this `PartialVersion` has no point or minor number, the
+    /// given version is assumed to be compatible.
     ///
     /// For versions of PostgreSQL after and including 10, this means that the
     /// given version's major number must match exactly, and the minor number
@@ -120,7 +127,7 @@ impl PartialVersion {
         }
     }
 
-    /// Remove minor/patch number.
+    /// Remove minor number.
     pub fn widened(&self) -> PartialVersion {
         use PartialVersion::*;
         match self {

--- a/src/version/partial.rs
+++ b/src/version/partial.rs
@@ -8,9 +8,12 @@ use super::VersionError;
 
 #[derive(Copy, Clone, Debug)]
 pub enum PartialVersion {
-    A(u32, u32, u32),
-    B(u32, u32),
-    C(u32),
+    /// Major, Minor, Patch.
+    Mmp(u32, u32, u32),
+    /// Major, Minor.
+    Mm(u32, u32),
+    /// Major.
+    M(u32),
 }
 
 impl PartialVersion {
@@ -23,10 +26,10 @@ impl PartialVersion {
     #[allow(dead_code)]
     pub fn sort_key(&self) -> (u32, Option<u32>, Option<u32>) {
         use PartialVersion::*;
-        match self {
-            A(a, b, c) => (*a, Some(*b), Some(*c)),
-            B(a, b) => (*a, Some(*b), None),
-            C(a) => (*a, None, None),
+        match *self {
+            Mmp(a, b, c) => (a, Some(b), Some(c)),
+            Mm(a, b) => (a, Some(b), None),
+            M(a) => (a, None, None),
         }
     }
 }
@@ -41,15 +44,15 @@ impl PartialOrd for PartialVersion {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         use PartialVersion::*;
         match (*self, *other) {
-            (A(x1, x2, x3), A(y1, y2, y3)) => (x1, x2, x3).partial_cmp(&(y1, y2, y3)),
-            (A(x1, x2, x3), B(y1, y2)) => (x1, x2, x3).partial_cmp(&(y1, y2, 0)),
-            (A(x1, x2, x3), C(y1)) => (x1, x2, x3).partial_cmp(&(y1, 0, 0)),
-            (B(x1, x2), A(y1, y2, y3)) => (x1, x2, 0).partial_cmp(&(y1, y2, y3)),
-            (B(x1, x2), B(y1, y2)) => (x1, x2).partial_cmp(&(y1, y2)),
-            (B(x1, x2), C(y1)) => (x1, x2).partial_cmp(&(y1, 0)),
-            (C(x1), A(y1, y2, y3)) => (x1, 0, 0).partial_cmp(&(y1, y2, y3)),
-            (C(x1), B(y1, y2)) => (x1, 0).partial_cmp(&(y1, y2)),
-            (C(x1), C(y1)) => x1.partial_cmp(&y1),
+            (Mmp(x1, x2, x3), Mmp(y1, y2, y3)) => (x1, x2, x3).partial_cmp(&(y1, y2, y3)),
+            (Mmp(x1, x2, x3), Mm(y1, y2)) => (x1, x2, x3).partial_cmp(&(y1, y2, 0)),
+            (Mmp(x1, x2, x3), M(y1)) => (x1, x2, x3).partial_cmp(&(y1, 0, 0)),
+            (Mm(x1, x2), Mmp(y1, y2, y3)) => (x1, x2, 0).partial_cmp(&(y1, y2, y3)),
+            (Mm(x1, x2), Mm(y1, y2)) => (x1, x2).partial_cmp(&(y1, y2)),
+            (Mm(x1, x2), M(y1)) => (x1, x2).partial_cmp(&(y1, 0)),
+            (M(x1), Mmp(y1, y2, y3)) => (x1, 0, 0).partial_cmp(&(y1, y2, y3)),
+            (M(x1), Mm(y1, y2)) => (x1, 0).partial_cmp(&(y1, y2)),
+            (M(x1), M(y1)) => x1.partial_cmp(&y1),
         }
     }
 }
@@ -57,9 +60,9 @@ impl PartialOrd for PartialVersion {
 impl fmt::Display for PartialVersion {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::A(a, b, c) => fmt.pad(&format!("{}.{}.{}", a, b, c)),
-            Self::B(a, b) => fmt.pad(&format!("{}.{}", a, b)),
-            Self::C(a) => fmt.pad(&format!("{}", a)),
+            Self::Mmp(a, b, c) => fmt.pad(&format!("{}.{}.{}", a, b, c)),
+            Self::Mm(a, b) => fmt.pad(&format!("{}.{}", a, b)),
+            Self::M(a) => fmt.pad(&format!("{}", a)),
         }
     }
 }
@@ -75,9 +78,9 @@ impl FromStr for PartialVersion {
                 caps.get(2).and_then(|n| n.as_str().parse::<u32>().ok()),
                 caps.get(3).and_then(|n| n.as_str().parse::<u32>().ok()),
             ) {
-                (Some(a), Some(b), Some(c)) => Ok(Self::A(a, b, c)),
-                (Some(a), Some(b), _) => Ok(Self::B(a, b)),
-                (Some(a), _, _) => Ok(Self::C(a)),
+                (Some(a), Some(b), Some(c)) => Ok(Self::Mmp(a, b, c)),
+                (Some(a), Some(b), _) => Ok(Self::Mm(a, b)),
+                (Some(a), _, _) => Ok(Self::M(a)),
                 _ => Err(VersionError::BadlyFormed),
             },
             None => Err(VersionError::Missing),
@@ -95,12 +98,12 @@ mod tests {
 
     #[test]
     fn parses_version_below_10() {
-        assert_eq!(Ok(A(9, 6, 17)), "9.6.17".parse());
+        assert_eq!(Ok(Mmp(9, 6, 17)), "9.6.17".parse());
     }
 
     #[test]
     fn parses_version_above_10() {
-        assert_eq!(Ok(B(12, 2)), "12.2".parse());
+        assert_eq!(Ok(Mm(12, 2)), "12.2".parse());
     }
 
     #[test]
@@ -116,26 +119,26 @@ mod tests {
 
     #[test]
     fn displays_version_below_10() {
-        assert_eq!("9.6.17", format!("{}", A(9, 6, 17)));
+        assert_eq!("9.6.17", format!("{}", Mmp(9, 6, 17)));
     }
 
     #[test]
     fn displays_version_above_10() {
-        assert_eq!("12.2", format!("{}", B(12, 2)));
+        assert_eq!("12.2", format!("{}", Mm(12, 2)));
     }
 
     #[test]
     fn partial_ord_works_as_expected() {
         let mut versions = vec![
-            A(9, 10, 11),
-            A(9, 10, 12),
-            B(8, 11),
-            B(9, 11),
-            B(9, 12),
-            B(10, 11),
-            C(8),
-            C(9),
-            C(11),
+            Mmp(9, 10, 11),
+            Mmp(9, 10, 12),
+            Mm(8, 11),
+            Mm(9, 11),
+            Mm(9, 12),
+            Mm(10, 11),
+            M(8),
+            M(9),
+            M(11),
         ];
         let mut rng = thread_rng();
         for _ in 0..1000 {
@@ -144,15 +147,15 @@ mod tests {
             assert_eq!(
                 versions,
                 vec![
-                    C(8),
-                    B(8, 11),
-                    C(9),
-                    A(9, 10, 11),
-                    A(9, 10, 12),
-                    B(9, 11),
-                    B(9, 12),
-                    B(10, 11),
-                    C(11),
+                    M(8),
+                    Mm(8, 11),
+                    M(9),
+                    Mmp(9, 10, 11),
+                    Mmp(9, 10, 12),
+                    Mm(9, 11),
+                    Mm(9, 12),
+                    Mm(10, 11),
+                    M(11),
                 ]
             );
         }
@@ -161,17 +164,17 @@ mod tests {
     #[test]
     fn sort_key_works_as_expected() {
         let mut versions = vec![
-            A(9, 0, 0),
-            A(9, 10, 11),
-            A(9, 10, 12),
-            B(9, 0),
-            B(8, 11),
-            B(9, 11),
-            B(9, 12),
-            B(10, 11),
-            C(8),
-            C(9),
-            C(11),
+            Mmp(9, 0, 0),
+            Mmp(9, 10, 11),
+            Mmp(9, 10, 12),
+            Mm(9, 0),
+            Mm(8, 11),
+            Mm(9, 11),
+            Mm(9, 12),
+            Mm(10, 11),
+            M(8),
+            M(9),
+            M(11),
         ];
         let mut rng = thread_rng();
         for _ in 0..1000 {
@@ -180,17 +183,17 @@ mod tests {
             assert_eq!(
                 versions,
                 vec![
-                    C(8),
-                    B(8, 11),
-                    C(9),
-                    B(9, 0),
-                    A(9, 0, 0),
-                    A(9, 10, 11),
-                    A(9, 10, 12),
-                    B(9, 11),
-                    B(9, 12),
-                    B(10, 11),
-                    C(11),
+                    M(8),
+                    Mm(8, 11),
+                    M(9),
+                    Mm(9, 0),
+                    Mmp(9, 0, 0),
+                    Mmp(9, 10, 11),
+                    Mmp(9, 10, 12),
+                    Mm(9, 11),
+                    Mm(9, 12),
+                    Mm(10, 11),
+                    M(11),
                 ]
             );
         }


### PR DESCRIPTION
This provides the pieces necessary to detect the cluster runtime. Later work will use this to select the correct runtime when operating on a cluster.