### PR TITLE
Switch to `--mode <MODE>` instead of separate flags

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -74,43 +74,18 @@ pub struct ClusterArgs {
     )]
     pub dir: PathBuf,
 
-    /// Run the cluster in a "faster" mode.
+    /// Run the cluster in a "safer" or "faster" mode.
     ///
-    /// This disables `fsync`, `full_page_writes`, and `synchronous_commit` in
-    /// the cluster. This can make the cluster faster but it can also lead to
-    /// unrecoverable data corruption in the event of a power failure or system
-    /// crash. Useful for tests, for example, but probably not production.
+    /// DANGER! Choosing "faster-but-less-safe" makes the cluster faster but it
+    /// can lead to unrecoverable data corruption in the event of a power
+    /// failure or system crash.
     ///
-    /// In the future this may make additional or different changes. See
-    /// https://www.postgresql.org/docs/16/runtime-config-wal.html for more
-    /// information.
-    ///
-    /// This option is STICKY. Once you've used it, the cluster will be
-    /// configured to be "faster but less safe" and you do not need to specify
-    /// it again. To find out if the cluster is running in this mode, open a
-    /// `psql` shell (e.g. `postgresfixture shell`) and run `SHOW fsync; SHOW
-    /// full_page_writes; SHOW synchronous_commit;`.
-    #[clap(long = "faster-but-less-safe", action = clap::ArgAction::SetTrue, default_value_t = false, display_order = 2)]
-    pub faster: bool,
-
-    /// Run the cluster in a "safer" mode.
-    ///
-    /// This is the opposite of `--faster-but-less-safe`, i.e. it runs with
-    /// `fsync`, `full_page_writes`, and `synchronous_commit` enabled in the
-    /// cluster.
-    ///
-    /// NOTE: this actually *resets* the `fsync`, `full_page_writes`, and
-    /// `synchronous_commit` settings to their defaults. Unless they've been
-    /// configured differently in the cluster's `postgresql.conf`, the default
-    /// for these settings is on/enabled.
-    ///
-    /// This option is STICKY. Once you've used it, the cluster will be
-    /// configured to be "slower and safer" and you do not need to specify it
-    /// again. To find out if the cluster is running in this mode, open a `psql`
-    /// shell (e.g. `postgresfixture shell`) and run `SHOW fsync; SHOW
-    /// full_page_writes; SHOW synchronous_commit;`.
-    #[clap(long = "slower-but-safer", action = clap::ArgAction::SetTrue, default_value_t = false, display_order = 3, conflicts_with = "faster")]
-    pub slower: bool,
+    /// The mode is STICKY. Running with a mode reconfigures the cluster, and it
+    /// will continue to run in that mode. To find out which mode the cluster is
+    /// configured for, open a `psql` shell (e.g. `postgresfixture shell`) and
+    /// run `SHOW fsync; SHOW full_page_writes; SHOW synchronous_commit;`.
+    #[clap(long = "mode", display_order = 4)]
+    pub mode: Option<Mode>,
 }
 
 #[derive(Args)]
@@ -133,4 +108,15 @@ pub struct LifecycleArgs {
     /// DIRECTORY. The default is to NOT destroy the cluster.
     #[clap(long = "destroy", display_order = 100)]
     pub destroy: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, clap::ValueEnum)]
+pub enum Mode {
+    /// Resets fsync, full_page_writes, and synchronous_commit to defaults.
+    #[value(name = "slower-but-safer", alias = "safe")]
+    Slow,
+
+    /// Disable fsync, full_page_writes, and synchronous_commit. DANGER!
+    #[value(name = "faster-but-less-safe", alias = "fast")]
+    Fast,
 }


### PR DESCRIPTION
The `--faster-but-less-safe` and `--slower-but-safer` flags have been folded into a single `--mode` option.